### PR TITLE
Removes the requirement for rating to be declared upon user creation

### DIFF
--- a/db/migrate/20180820152755_change_column_of_users.rb
+++ b/db/migrate/20180820152755_change_column_of_users.rb
@@ -1,0 +1,5 @@
+class ChangeColumnOfUsers < ActiveRecord::Migration[5.2]
+  def change
+    change_column :users, :rating, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_20_150219) do
+ActiveRecord::Schema.define(version: 2018_08_20_152755) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,7 +50,7 @@ ActiveRecord::Schema.define(version: 2018_08_20_150219) do
     t.string "username"
     t.string "first_name"
     t.string "last_name"
-    t.integer "rating"
+    t.integer "rating", default: 0
     t.text "description"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
can now create new user with `User.create!(email:"username@gmail.com", password:"hunter2")`